### PR TITLE
Fix package caching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: publish
 
 on:
   schedule:
-    # Runs on the 1st and 15th of every month at 1am
-    - cron: '00 1 1,15 * *'
+    # Runs on the 1st and 15th of every month at 2am CST (7am UTC)
+    - cron: '00 7 1,15 * *'
   push:
     branches: [main]
     paths: [dockerfiles/**]

--- a/dockerfiles/Dockerfile-dim
+++ b/dockerfiles/Dockerfile-dim
@@ -118,19 +118,17 @@ RUN mkdir -p /home/root/opt/bin \
 && ln -s /home/root/opt/venv/bin/virtualenv virtualenv
 ENV PATH="/home/root/opt/bin:$PATH"
 
-# pre-cache some packages
-RUN curl https://raw.githubusercontent.com/proxystore/proxystore/main/requirements-dev.txt --output /tmp/requirements-dev.txt \
-&& printf "aiortc\nhypercorn[uvloop]\npsutil\npython-daemon\nquart\nwebsockets" >> /tmp/requirements.txt \
-&& python3.7 -m venv /home/root/opt/venv3.7 \
+# install proxystore to pre-cache some packages
+RUN python3.7 -m venv /home/root/opt/venv3.7 \
 && python3.8 -m venv /home/root/opt/venv3.8 \
 && python3.9 -m venv /home/root/opt/venv3.9 \
 && python3.10 -m venv /home/root/opt/venv3.10 \
 && python3.11 -m venv /home/root/opt/venv3.11 \
-&& /home/root/opt/venv3.7/bin/pip install -r /tmp/requirements-dev.txt \
-&& /home/root/opt/venv3.8/bin/pip install -r /tmp/requirements-dev.txt \
-&& /home/root/opt/venv3.9/bin/pip install -r /tmp/requirements-dev.txt \
-&& /home/root/opt/venv3.10/bin/pip install -r /tmp/requirements-dev.txt \
-&& /home/root/opt/venv3.11/bin/pip install -r /tmp/requirements-dev.txt \
+&& /home/root/opt/venv3.7/bin/pip install proxystore[dev,endpoints] \
+&& /home/root/opt/venv3.8/bin/pip install proxystore[dev,endpoints] \
+&& /home/root/opt/venv3.9/bin/pip install proxystore[dev,endpoints] \
+&& /home/root/opt/venv3.10/bin/pip install proxystore[dev,endpoints] \
+&& /home/root/opt/venv3.11/bin/pip install proxystore[dev,endpoints] \
 && rm -rf /home/root/opt/venv3.7 \
 && rm -rf /home/root/opt/venv3.9 \
 && rm -rf /home/root/opt/venv3.9 \


### PR DESCRIPTION
ProxyStore no longer has a `requirement-dev.txt` so builds broke. To fix we now just `pip install proxystore` to cache all the dependencies.